### PR TITLE
Add pre-commit hook definition for checking if a repository signature is present

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,11 +3,10 @@
 # See usage instructions at http://pre-commit.com
 
 - id: ansible-sign
-  name: Ansible-sign
+  name: Verify Ansible-sign signature
   description: This hook runs ansible-sign.
-  entry: ansible-sign project gpg-sign .
+  entry: ansible-sign project gpg-verify .
   language: python
-  # do not pass files to ansible-lint, see:
-  # https://github.com/ansible/ansible-lint/issues/611
+  # do not pass files as we need to scan the directory with the MANIFEST.in
   pass_filenames: false
   always_run: true


### PR DESCRIPTION
Added a pre-commit hook configuration.

This configuration only verifies if the code has been signed, as the pre-commit framework does not accept changes to files when run. And as the signature file changes each time, that's no option :-)