### PR TITLE
Use pre-commit to run linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+---
+repos:
+  - repo: meta
+    hooks:
+      - id: check-useless-excludes
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.24.2
+    hooks:
+      - id: toml-sort-fix
+        alias: toml
+
+  - repo: https://github.com/tox-dev/tox-ini-fmt
+    rev: 1.5.0
+    hooks:
+      - id: tox-ini-fmt
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.0
+    hooks:
+      - id: ruff-format
+        alias: ruff
+      - id: ruff-check
+        alias: ruff

--- a/.yamllint
+++ b/.yamllint
@@ -14,3 +14,7 @@ rules:
   truthy:
     ignore: |
       .github
+
+ignore: |
+  .tox
+strict: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ $ workon ansible-sign
 
 ## Linting and Unit Tests
 
-`tox` is used to run linters (`black`, `flake8` and `yamllint`) and tests.
+`tox` is used to run linters and tests.
 
 ```
 $ pip install tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,64 @@
-[build-system]
-# AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
-requires = ["setuptools>=46.1.0", "setuptools_scm[toml]>=5"]
-build-backend = "setuptools.build_meta"
+[tool.ruff]
+# Same as Black.
+line-length = 88
+preview = true
+
+[tool.ruff.lint]
+extend-unsafe-fixes = ["E501"]
+fixable = ["ALL"]
+ignore = [
+  # temporary disabled during ruff adoption
+  "A",
+  "ANN",
+  "ARG",
+  "B",
+  "BLE",
+  "C",
+  "COM",
+  "CPY",
+  "D",
+  "DOC",
+  "EM",
+  "ERA",
+  "FBT",
+  "FIX",
+  "FURB",
+  "G",
+  "I001",
+  "INP",
+  "N",
+  "PGH",
+  "PLC",
+  "PLR",
+  "PLW",
+  "PT",
+  "PTH",
+  "RUF",
+  "SIM",
+  "T",
+  "TD",
+  "TRY",
+  "UP",
+  # disabled on purpose
+  "E501"
+]
+select = ["ALL"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["src"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["D", "S"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.setuptools_scm]
 # For smarter version schemes and other configuration options,
 # check out https://github.com/pypa/setuptools_scm
 version_scheme = "no-guess-dev"
 
-[tool.black]
-line-length = 160
-fast = true
+[tool.tomlsort]
+in_place = true
+sort_inline_tables = true
+sort_table_keys = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,19 +93,6 @@ testpaths = tests
 no_vcs = 1
 formats = bdist_wheel
 
-[flake8]
-# Some sane defaults for the code style checker flake8
-max_line_length = 160
-extend_ignore = E203, W503
-# ^  Black-compatible
-#    E203 and W503 have edge cases handled by black
-exclude =
-    .tox
-    build
-    dist
-    .eggs
-    docs/conf.py
-
 [pyscaffold]
 # PyScaffold's parameters when the project was created.
 # This will be used when updating. Do not change!

--- a/src/ansible_sign/checksum/base.py
+++ b/src/ansible_sign/checksum/base.py
@@ -88,11 +88,15 @@ class ChecksumFile:
             # if parsed is False:
             parsed = self._parse_gnu_style(line)
             if parsed is False:
-                raise InvalidChecksumLine(f"Unparsable checksum, line {idx + 1}: {line}")
+                raise InvalidChecksumLine(
+                    f"Unparsable checksum, line {idx + 1}: {line}"
+                )
             path = parsed[0]
             shasum = parsed[1]
             if path in checksums:
-                raise InvalidChecksumLine(f"Duplicate path in checksum, line {idx + 1}: {line}")
+                raise InvalidChecksumLine(
+                    f"Duplicate path in checksum, line {idx + 1}: {line}"
+                )
             checksums[path] = shasum
         return checksums
 

--- a/src/ansible_sign/checksum/differ/base.py
+++ b/src/ansible_sign/checksum/differ/base.py
@@ -19,12 +19,10 @@ class ChecksumFileExistenceDiffer:
 
     # These are tuples of path elements, compared to the path's parts (as
     # presented by pathlib).
-    ignored_paths = set(
-        [
-            ".ansible-sign",
-            ".ansible-sign/**",
-        ]
-    )
+    ignored_paths = set([
+        ".ansible-sign",
+        ".ansible-sign/**",
+    ])
 
     # Files that get added to the manifest in list_files() even if not
     # explicitly found by gather_files()

--- a/src/ansible_sign/checksum/differ/distlib_manifest.py
+++ b/src/ansible_sign/checksum/differ/distlib_manifest.py
@@ -20,7 +20,9 @@ class DistlibManifestChecksumFileExistenceDiffer(ChecksumFileExistenceDiffer):
 
         if not os.path.exists(manifest_path):
             # open() would do this, but let us be explicit, the file must exist.
-            raise FileNotFoundError(manifest_path, os.strerror(errno.ENOENT), manifest_path)
+            raise FileNotFoundError(
+                manifest_path, os.strerror(errno.ENOENT), manifest_path
+            )
 
         with open(manifest_path, "r") as f:
             manifest_in = f.read()

--- a/src/ansible_sign/cli.py
+++ b/src/ansible_sign/cli.py
@@ -28,7 +28,12 @@ class AnsibleSignCLI:
         self.logger.debug("Parsing args: %s", str(args))
         self.args = self.parse_args(args)
         logformat = "[%(asctime)s] %(levelname)s:%(name)s:%(message)s"
-        logging.basicConfig(level=self.args.loglevel, stream=sys.stdout, format=logformat, datefmt="%Y-%m-%d %H:%M:%S")
+        logging.basicConfig(
+            level=self.args.loglevel,
+            stream=sys.stdout,
+            format=logformat,
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
 
     def run_command(self):
         """
@@ -57,7 +62,9 @@ class AnsibleSignCLI:
           :obj:`argparse.Namespace`: command line parameters namespace
         """
 
-        parser = argparse.ArgumentParser(description="Signing and validation for Ansible content")
+        parser = argparse.ArgumentParser(
+            description="Signing and validation for Ansible content"
+        )
         parser.add_argument(
             "--version",
             action="version",
@@ -80,7 +87,9 @@ class AnsibleSignCLI:
         )
 
         # Future-proofing for future content types.
-        content_type_parser = parser.add_subparsers(required=True, dest="content_type", metavar="CONTENT_TYPE")
+        content_type_parser = parser.add_subparsers(
+            required=True, dest="content_type", metavar="CONTENT_TYPE"
+        )
 
         project = content_type_parser.add_parser(
             "project",
@@ -91,12 +100,16 @@ class AnsibleSignCLI:
         # command: gpg-verify
         cmd_gpg_verify = project_commands.add_parser(
             "gpg-verify",
-            help=("Perform signature validation AND checksum verification on the checksum manifest"),
+            help=(
+                "Perform signature validation AND checksum verification on the checksum manifest"
+            ),
         )
         cmd_gpg_verify.set_defaults(func=self.gpg_verify)
         cmd_gpg_verify.add_argument(
             "--keyring",
-            help=("The GPG keyring file to use to find the matching public key. (default: the user's default keyring)"),
+            help=(
+                "The GPG keyring file to use to find the matching public key. (default: the user's default keyring)"
+            ),
             required=False,
             metavar="KEYRING",
             dest="keyring",
@@ -104,7 +117,9 @@ class AnsibleSignCLI:
         )
         cmd_gpg_verify.add_argument(
             "--gnupg-home",
-            help=("A valid GnuPG home directory. (default: the GnuPG default, usually ~/.gnupg)"),
+            help=(
+                "A valid GnuPG home directory. (default: the GnuPG default, usually ~/.gnupg)"
+            ),
             required=False,
             metavar="GNUPG_HOME",
             dest="gnupg_home",
@@ -124,7 +139,9 @@ class AnsibleSignCLI:
         cmd_gpg_sign.set_defaults(func=self.gpg_sign)
         cmd_gpg_sign.add_argument(
             "--fingerprint",
-            help=("The GPG private key fingerprint to sign with. (default: First usable key in the user's keyring)"),
+            help=(
+                "The GPG private key fingerprint to sign with. (default: First usable key in the user's keyring)"
+            ),
             required=False,
             metavar="PRIVATE_KEY",
             dest="fingerprint",
@@ -141,7 +158,9 @@ class AnsibleSignCLI:
         )
         cmd_gpg_sign.add_argument(
             "--gnupg-home",
-            help=("A valid GnuPG home directory. (default: the GnuPG default, usually ~/.gnupg)"),
+            help=(
+                "A valid GnuPG home directory. (default: the GnuPG default, usually ~/.gnupg)"
+            ),
             required=False,
             metavar="GNUPG_HOME",
             dest="gnupg_home",
@@ -161,19 +180,27 @@ class AnsibleSignCLI:
             manifest = checksum.generate_gnu_style()
         except FileNotFoundError as e:
             if os.path.islink(e.filename):
-                self._error(f"Broken symlink found at {e.filename} -- this is not supported. Aborting.")
+                self._error(
+                    f"Broken symlink found at {e.filename} -- this is not supported. Aborting."
+                )
                 return False
 
             if e.filename.endswith("/MANIFEST.in"):
-                self._error("Could not find a MANIFEST.in file in the specified project.")
-                self._note("If you are attempting to sign a project, please create this file.")
+                self._error(
+                    "Could not find a MANIFEST.in file in the specified project."
+                )
+                self._note(
+                    "If you are attempting to sign a project, please create this file."
+                )
                 self._note("See the ansible-sign documentation for more information.")
                 return False
             raise e
         except DistlibException as e:
             self._error(f"An error was encountered while parsing MANIFEST.in: {e}")
             if self.args.loglevel != logging.DEBUG:
-                self._note("You can use the --debug global flag to view the full traceback.")
+                self._note(
+                    "You can use the --debug global flag to view the full traceback."
+                )
             self.logger.debug(e, exc_info=e)
             return False
         for warning in checksum.warnings:
@@ -221,7 +248,9 @@ class AnsibleSignCLI:
         """
         differ = DistlibManifestChecksumFileExistenceDiffer
         checksum = ChecksumFile(self.args.project_root, differ=differ)
-        checksum_path = os.path.join(self.args.project_root, ".ansible-sign", "sha256sum.txt")
+        checksum_path = os.path.join(
+            self.args.project_root, ".ansible-sign", "sha256sum.txt"
+        )
         checksum_file_contents = open(checksum_path, "r").read()
 
         try:
@@ -238,18 +267,26 @@ class AnsibleSignCLI:
             return 2
         except FileNotFoundError as e:
             if os.path.islink(e.filename):
-                self._error(f"Broken symlink found at {e.filename} -- this is not supported. Aborting.")
+                self._error(
+                    f"Broken symlink found at {e.filename} -- this is not supported. Aborting."
+                )
                 return 1
 
             if e.filename.endswith("MANIFEST.in"):
-                self._error("Could not find a MANIFEST.in file in the specified project.")
-                self._note("If you are attempting to verify a signed project, please ensure that the project directory includes this file after signing.")
+                self._error(
+                    "Could not find a MANIFEST.in file in the specified project."
+                )
+                self._note(
+                    "If you are attempting to verify a signed project, please ensure that the project directory includes this file after signing."
+                )
                 self._note("See the ansible-sign documentation for more information.")
                 return 1
         except DistlibException as e:
             self._error(f"An error was encountered while parsing MANIFEST.in: {e}")
             if self.args.loglevel != logging.DEBUG:
-                self._note("You can use the --debug global flag to view the full traceback.")
+                self._note(
+                    "You can use the --debug global flag to view the full traceback."
+                )
             self.logger.debug(e, exc_info=e)
             return 1
 
@@ -260,8 +297,12 @@ class AnsibleSignCLI:
         return 0
 
     def gpg_verify(self):
-        signature_file = os.path.join(self.args.project_root, ".ansible-sign", "sha256sum.txt.sig")
-        manifest_file = os.path.join(self.args.project_root, ".ansible-sign", "sha256sum.txt")
+        signature_file = os.path.join(
+            self.args.project_root, ".ansible-sign", "sha256sum.txt.sig"
+        )
+        manifest_file = os.path.join(
+            self.args.project_root, ".ansible-sign", "sha256sum.txt"
+        )
 
         if not os.path.exists(signature_file):
             self._error(f"Signature file does not exist: {signature_file}")
@@ -276,7 +317,9 @@ class AnsibleSignCLI:
             return 1
 
         if self.args.gnupg_home is not None and not os.path.isdir(self.args.gnupg_home):
-            self._error(f"Specified GnuPG home is not a directory: {self.args.gnupg_home}")
+            self._error(
+                f"Specified GnuPG home is not a directory: {self.args.gnupg_home}"
+            )
             return 1
 
         verifier = GPGVerifier(
@@ -317,7 +360,9 @@ class AnsibleSignCLI:
 
     def gpg_sign(self):
         # Step 1: Manifest
-        manifest_path = os.path.join(self.args.project_root, ".ansible-sign", "sha256sum.txt")
+        manifest_path = os.path.join(
+            self.args.project_root, ".ansible-sign", "sha256sum.txt"
+        )
         checksum_file_contents = self._generate_checksum_manifest()
         if checksum_file_contents is False:
             return 1
@@ -330,12 +375,16 @@ class AnsibleSignCLI:
             self.logger.debug("Prompting for GPG key passphrase")
             passphrase = getpass.getpass("GPG Key Passphrase: ")
         elif "ANSIBLE_SIGN_GPG_PASSPHRASE" in os.environ:
-            self.logger.debug("Taking GPG key passphrase from ANSIBLE_SIGN_GPG_PASSPHRASE env var")
+            self.logger.debug(
+                "Taking GPG key passphrase from ANSIBLE_SIGN_GPG_PASSPHRASE env var"
+            )
             passphrase = os.environ["ANSIBLE_SIGN_GPG_PASSPHRASE"]
         else:
             os.environ["GPG_TTY"] = os.ttyname(sys.stdin.fileno())
 
-        signature_path = os.path.join(self.args.project_root, ".ansible-sign", "sha256sum.txt.sig")
+        signature_path = os.path.join(
+            self.args.project_root, ".ansible-sign", "sha256sum.txt.sig"
+        )
         signer = GPGSigner(
             manifest_path=manifest_path,
             output_path=signature_path,

--- a/src/ansible_sign/signing/gpg/verifier.py
+++ b/src/ansible_sign/signing/gpg/verifier.py
@@ -17,7 +17,9 @@ __license__ = "MIT"
 
 
 class GPGVerifier(SignatureVerifier):
-    def __init__(self, manifest_path, detached_signature_path, gpg_home=None, keyring=None):
+    def __init__(
+        self, manifest_path, detached_signature_path, gpg_home=None, keyring=None
+    ):
         super(GPGVerifier, self).__init__()
 
         if manifest_path is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,9 @@ from ansible_sign.signing import GPGSigner
 
 if gnupg.__version__ >= "1.0":
     # https://stackoverflow.com/q/35028852/99834
-    pytest.exit("Unsupported gnupg library found, repair it with: pip3 uninstall -y gnupg && pip3 install python-gnupg")
+    pytest.exit(
+        "Unsupported gnupg library found, repair it with: pip3 uninstall -y gnupg && pip3 install python-gnupg"
+    )
 
 
 @pytest.fixture
@@ -68,7 +70,15 @@ def gpg_home_with_hao_pubkey(tmp_path):
     home = tmp_path / "gpg-home-with-hao-pubkey"
     home.mkdir()
     gpg = gnupg.GPG(gnupghome=home)
-    pubkey = open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures", "gpgkeys", "hao_pubkey.txt"), "r").read()
+    pubkey = open(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "fixtures",
+            "gpgkeys",
+            "hao_pubkey.txt",
+        ),
+        "r",
+    ).read()
     gpg.import_keys(pubkey)
     yield home
 
@@ -96,7 +106,9 @@ def unsigned_project_with_checksum_manifest(tmp_path):
 
 
 @pytest.fixture
-def unsigned_project_with_broken_checksum_manifest(unsigned_project_with_checksum_manifest):
+def unsigned_project_with_broken_checksum_manifest(
+    unsigned_project_with_checksum_manifest,
+):
     """
     Creates a project directory (at a temporary location) with a broken
     (syntactically invalid) checksum file.
@@ -104,7 +116,9 @@ def unsigned_project_with_broken_checksum_manifest(unsigned_project_with_checksu
     Uses the 'manifest-success' checksum fixture directory as its base and
     modifies the checksum manifest after copying.
     """
-    manifest = unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt"
+    manifest = (
+        unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt"
+    )
     with fileinput.input(files=manifest, inplace=True) as f:
         for idx, line in enumerate(f):
             line = line.strip()
@@ -128,7 +142,9 @@ def unsigned_project_with_broken_symlink(unsigned_project_with_checksum_manifest
 
 
 @pytest.fixture
-def unsigned_project_with_modified_checksum_manifest(unsigned_project_with_checksum_manifest):
+def unsigned_project_with_modified_checksum_manifest(
+    unsigned_project_with_checksum_manifest,
+):
     """
     Creates a project directory (at a temporary location) with a changed
     checksum file that contains wrong hashes.
@@ -136,13 +152,20 @@ def unsigned_project_with_modified_checksum_manifest(unsigned_project_with_check
     Uses the 'manifest-success' checksum fixture directory as its base and
     modifies the checksum manifest after copying.
     """
-    manifest = unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt"
+    manifest = (
+        unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt"
+    )
     with fileinput.input(files=manifest, inplace=True) as f:
         for idx, line in enumerate(f):
             line = line.strip()
             if idx % 2 == 0:
                 # Change some of the checksum lines.
-                print(line.replace("2", "3").replace("a", "b").replace("7", "a").replace("c", "2"))
+                print(
+                    line.replace("2", "3")
+                    .replace("a", "b")
+                    .replace("7", "a")
+                    .replace("c", "2")
+                )
             else:
                 print(line)
     yield unsigned_project_with_checksum_manifest
@@ -153,8 +176,12 @@ def _sign_project(gpg_home_with_secret_key, unsigned_project_with_checksum_manif
     GPG-sign a project. Usually the arguments are temp directories produced by
     other fixtures above.
     """
-    out = unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt.sig"
-    manifest_path = unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt"
+    out = (
+        unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt.sig"
+    )
+    manifest_path = (
+        unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt"
+    )
     signer = GPGSigner(
         manifest_path=manifest_path,
         output_path=out,
@@ -177,7 +204,9 @@ def signed_project_and_gpg(
     """
     Sign a project that has a valid manifest.
     """
-    yield _sign_project(gpg_home_with_secret_key, unsigned_project_with_checksum_manifest)
+    yield _sign_project(
+        gpg_home_with_secret_key, unsigned_project_with_checksum_manifest
+    )
 
 
 @pytest.fixture
@@ -188,7 +217,9 @@ def signed_project_broken_manifest(
     """
     Sign a project that has a broken manifest.
     """
-    yield _sign_project(gpg_home_with_secret_key, unsigned_project_with_broken_checksum_manifest)
+    yield _sign_project(
+        gpg_home_with_secret_key, unsigned_project_with_broken_checksum_manifest
+    )
 
 
 @pytest.fixture
@@ -199,7 +230,9 @@ def signed_project_modified_manifest(
     """
     Sign a project that has a modified manifest.
     """
-    yield _sign_project(gpg_home_with_secret_key, unsigned_project_with_modified_checksum_manifest)
+    yield _sign_project(
+        gpg_home_with_secret_key, unsigned_project_with_modified_checksum_manifest
+    )
 
 
 @pytest.fixture
@@ -210,7 +243,9 @@ def signed_project_missing_manifest(
     """
     Sign a project that has a missing manifest.
     """
-    (project, gpghome) = _sign_project(gpg_home_with_secret_key, unsigned_project_with_checksum_manifest)
+    (project, gpghome) = _sign_project(
+        gpg_home_with_secret_key, unsigned_project_with_checksum_manifest
+    )
     manifest = project / ".ansible-sign" / "sha256sum.txt"
     os.remove(manifest)
     yield (project, gpghome)
@@ -226,7 +261,9 @@ def signed_project_with_different_gpg_home(
     Sign a project but 'lose' the key it was signed with by returning an
     unrelated gnupg home directory.
     """
-    (project, gpghome) = _sign_project(gpg_home_with_secret_key, unsigned_project_with_checksum_manifest)
+    (project, gpghome) = _sign_project(
+        gpg_home_with_secret_key, unsigned_project_with_checksum_manifest
+    )
     yield (project, gpg_home_with_hao_pubkey)
 
 
@@ -238,7 +275,9 @@ def signed_project_broken_manifest_in(
     """
     Sign a project but then break its MANIFEST.in.
     """
-    (project, gpghome) = _sign_project(gpg_home_with_secret_key, unsigned_project_with_checksum_manifest)
+    (project, gpghome) = _sign_project(
+        gpg_home_with_secret_key, unsigned_project_with_checksum_manifest
+    )
     manifest_in = project / "MANIFEST.in"
     with open(manifest_in, "w") as f:
         f.write("invalid-directive foo bar\n")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 libtmux
 pytest
 pytest-mock
-flake8
 yamllint
-black>=24.3.0
+pre-commit
+pre-commit-uv

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -1,7 +1,12 @@
 import os
 import pytest
 
-from ansible_sign.checksum import ChecksumFile, InvalidChecksumLine, ChecksumMismatch, DistlibManifestChecksumFileExistenceDiffer
+from ansible_sign.checksum import (
+    ChecksumFile,
+    InvalidChecksumLine,
+    ChecksumMismatch,
+    DistlibManifestChecksumFileExistenceDiffer,
+)
 
 __author__ = "Rick Elrod"
 __copyright__ = "(c) 2022 Red Hat, Inc."
@@ -91,9 +96,18 @@ def test_parse_manifest_with_blank_lines():
     checksum = ChecksumFile("/tmp", differ=None)
     parsed = checksum.parse(BLANK_LINES_FIXTURE)
     assert len(parsed) == 3
-    assert parsed["MANIFEST.in"] == "d2d1320f7f4fe3abafe92765732d2aa6c097e7adf05bbd53481777d4a1f0cdab"
-    assert parsed["dir/hello2"] == "dc920c7f31a4869fb9f94519a4a77f6c7c43c6c3e66b0e57a5bcda52e9b02ce3"
-    assert parsed["hello1"] == "2a1b1ab320215205675234744dc03f028b46da4d94657bbb7dca7b1a3a25e91e"
+    assert (
+        parsed["MANIFEST.in"]
+        == "d2d1320f7f4fe3abafe92765732d2aa6c097e7adf05bbd53481777d4a1f0cdab"
+    )
+    assert (
+        parsed["dir/hello2"]
+        == "dc920c7f31a4869fb9f94519a4a77f6c7c43c6c3e66b0e57a5bcda52e9b02ce3"
+    )
+    assert (
+        parsed["hello1"]
+        == "2a1b1ab320215205675234744dc03f028b46da4d94657bbb7dca7b1a3a25e91e"
+    )
 
 
 def test_parse_manifest_with_only_blank_lines():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,9 @@ from ansible_sign.cli import main
 __author__ = "Rick Elrod"
 __copyright__ = "(c) 2022 Red Hat, Inc."
 __license__ = "MIT"
-IS_GITHUB_ACTION_MACOS = sys.platform == "darwin" and os.environ.get("CI", "false") == "true"
+IS_GITHUB_ACTION_MACOS = (
+    sys.platform == "darwin" and os.environ.get("CI", "false") == "true"
+)
 
 
 @pytest.mark.parametrize(
@@ -125,7 +127,9 @@ def test_main(capsys, args, exp_stdout_substr, exp_stderr_substr, exp_rc):
         ),
     ],
 )
-def test_main_with_pubkey_in_keyring(capsys, gpg_home_with_hao_pubkey, args, exp_stdout_substr, exp_stderr_substr, exp_rc):
+def test_main_with_pubkey_in_keyring(
+    capsys, gpg_home_with_hao_pubkey, args, exp_stdout_substr, exp_stderr_substr, exp_rc
+):
     """
     Test the CLI assuming that there is (only) a public key in the keyring.
     """
@@ -151,7 +155,10 @@ def test_main_with_pubkey_in_keyring(capsys, gpg_home_with_hao_pubkey, args, exp
             "",
             0,
             id="valid checksum file and signature",
-            marks=pytest.mark.xfail(IS_GITHUB_ACTION_MACOS, reason="https://github.com/ansible/ansible-sign/issues/51"),
+            marks=pytest.mark.xfail(
+                IS_GITHUB_ACTION_MACOS,
+                reason="https://github.com/ansible/ansible-sign/issues/51",
+            ),
         ),
         pytest.param(
             "signed_project_broken_manifest",
@@ -159,29 +166,52 @@ def test_main_with_pubkey_in_keyring(capsys, gpg_home_with_hao_pubkey, args, exp
             "",
             1,
             id="valid signature but broken checksum file",
-            marks=pytest.mark.xfail(IS_GITHUB_ACTION_MACOS, reason="https://github.com/ansible/ansible-sign/issues/51"),
+            marks=pytest.mark.xfail(
+                IS_GITHUB_ACTION_MACOS,
+                reason="https://github.com/ansible/ansible-sign/issues/51",
+            ),
         ),
-        pytest.param("signed_project_missing_manifest", "Checksum manifest file does not exist:", "", 1, id="missing checksum file entirely"),
+        pytest.param(
+            "signed_project_missing_manifest",
+            "Checksum manifest file does not exist:",
+            "",
+            1,
+            id="missing checksum file entirely",
+        ),
         pytest.param(
             "signed_project_modified_manifest",
             "Checksum validation failed.",
             "",
             2,
             id="checksum file with wrong hashes",
-            marks=pytest.mark.xfail(IS_GITHUB_ACTION_MACOS, reason="https://github.com/ansible/ansible-sign/issues/51"),
+            marks=pytest.mark.xfail(
+                IS_GITHUB_ACTION_MACOS,
+                reason="https://github.com/ansible/ansible-sign/issues/51",
+            ),
         ),
-        pytest.param("signed_project_with_different_gpg_home", "Re-run with the global --debug flag", "", 3, id="matching pubkey does not exist in gpg home"),
+        pytest.param(
+            "signed_project_with_different_gpg_home",
+            "Re-run with the global --debug flag",
+            "",
+            3,
+            id="matching pubkey does not exist in gpg home",
+        ),
         pytest.param(
             "signed_project_broken_manifest_in",
             "An error was encountered while parsing MANIFEST.in: unknown action 'invalid-directive'",
             "",
             1,
             id="broken MANIFEST.in after signing",
-            marks=pytest.mark.xfail(IS_GITHUB_ACTION_MACOS, reason="https://github.com/ansible/ansible-sign/issues/51"),
+            marks=pytest.mark.xfail(
+                IS_GITHUB_ACTION_MACOS,
+                reason="https://github.com/ansible/ansible-sign/issues/51",
+            ),
         ),
     ],
 )
-def test_gpg_verify_manifest_scenario(capsys, request, project_fixture, exp_stdout_substr, exp_stderr_substr, exp_rc):
+def test_gpg_verify_manifest_scenario(
+    capsys, request, project_fixture, exp_stdout_substr, exp_stderr_substr, exp_rc
+):
     """
     Test `ansible-sign project gpg-verify` given different project directory
     scenarios (fixtures).
@@ -216,7 +246,9 @@ def test_gpg_verify_manifest_scenario(capsys, request, project_fixture, exp_stdo
         "GPG signing with key that does NOT require passphrase",
     ],
 )
-def test_gpg_sign_with_gnupg_home(capsys, mocker, request, unsigned_project_with_checksum_manifest, use_passphrase):
+def test_gpg_sign_with_gnupg_home(
+    capsys, mocker, request, unsigned_project_with_checksum_manifest, use_passphrase
+):
     if use_passphrase:
         gpg_home = request.getfixturevalue("gpg_home_with_secret_key")
     else:
@@ -258,14 +290,21 @@ def test_gpg_sign_with_gnupg_home(capsys, mocker, request, unsigned_project_with
         m.assert_not_called()
 
 
-def test_gpg_sign_with_broken_symlink(capsys, unsigned_project_with_broken_symlink, gpg_home_with_secret_key_no_pass):
+def test_gpg_sign_with_broken_symlink(
+    capsys, unsigned_project_with_broken_symlink, gpg_home_with_secret_key_no_pass
+):
     """
     Test that we show a warning when there's a broken symlink in the project
     directory. This works around a distlib.manifest bug, but tests our handling
     of it.
     """
     project_root = str(unsigned_project_with_broken_symlink)
-    args = ["project", "gpg-sign", f"--gnupg-home={gpg_home_with_secret_key_no_pass}", project_root]
+    args = [
+        "project",
+        "gpg-sign",
+        f"--gnupg-home={gpg_home_with_secret_key_no_pass}",
+        project_root,
+    ]
     rc = main(args)
     captured = capsys.readouterr()
     assert "Broken symlink found at" in captured.out
@@ -281,7 +320,13 @@ def test_main_color(capsys, signed_project_and_gpg):
 
     (project_root, gpg_home) = signed_project_and_gpg
     args = ["project", "gpg-verify", f"--gnupg-home={gpg_home}", str(project_root)]
-    args_nocolor = ["--nocolor", "project", "gpg-verify", f"--gnupg-home={gpg_home}", str(project_root)]
+    args_nocolor = [
+        "--nocolor",
+        "project",
+        "gpg-verify",
+        f"--gnupg-home={gpg_home}",
+        str(project_root),
+    ]
 
     no_color_expected = "[OK   ]"
     color_expected = "[\033[92mOK   \033[0m]"

--- a/tests/test_cli_pinentry.py
+++ b/tests/test_cli_pinentry.py
@@ -8,8 +8,12 @@ __license__ = "MIT"
 
 
 # On MacOS the is a dialog popup asking for password, not a console prompt.
-@pytest.mark.skipif(sys.platform == "darwin", reason="Interactive test not working on MacOS")
-def test_pinentry_simple(tmux_session, gpg_home_with_secret_key, unsigned_project_with_checksum_manifest):
+@pytest.mark.skipif(
+    sys.platform == "darwin", reason="Interactive test not working on MacOS"
+)
+def test_pinentry_simple(
+    tmux_session, gpg_home_with_secret_key, unsigned_project_with_checksum_manifest
+):
     """Test that we can sign a file with a pinentry program."""
     home = gpg_home_with_secret_key
     window = tmux_session.new_window(window_name="test_pinentry_simple")

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -27,8 +27,12 @@ def test_gpg_simple_verify(tmp_path, directory, expected):
     pubkey = open(os.path.join(FIXTURES_DIR, "gpgkeys", "hao_pubkey.txt"), "r").read()
     gpg.import_keys(pubkey)
 
-    manifest_path = os.path.join(FIXTURES_DIR, "gpg", directory, ".ansible-sign", "sha256sum.txt")
-    signature_path = os.path.join(FIXTURES_DIR, "gpg", directory, ".ansible-sign", "sha256sum.txt.sig")
+    manifest_path = os.path.join(
+        FIXTURES_DIR, "gpg", directory, ".ansible-sign", "sha256sum.txt"
+    )
+    signature_path = os.path.join(
+        FIXTURES_DIR, "gpg", directory, ".ansible-sign", "sha256sum.txt.sig"
+    )
 
     verifier = GPGVerifier(
         manifest_path=manifest_path,
@@ -45,8 +49,12 @@ def test_gpg_simple_sign(
     gpg_home_with_secret_key,
     unsigned_project_with_checksum_manifest,
 ):
-    out = unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt.sig"
-    manifest_path = unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt"
+    out = (
+        unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt.sig"
+    )
+    manifest_path = (
+        unsigned_project_with_checksum_manifest / ".ansible-sign" / "sha256sum.txt"
+    )
     signer = GPGSigner(
         manifest_path=manifest_path,
         output_path=out,

--- a/tox.ini
+++ b/tox.ini
@@ -1,92 +1,84 @@
 [tox]
-minversion = 3.24
-envlist = py3,lint,docs
-isolated_build = True
-
+requires =
+    tox>=4.2
+env_list =
+    py3
+    lint
+    docs
 
 [testenv]
 description = Invoke pytest to run automated tests
 deps =
     -r {toxinidir}/tests/requirements.txt
-setenv =
-    TOXINIDIR = {toxinidir}
-passenv =
+extras =
+    testing
+pass_env =
     CI
     GITHUB_*
     HOME
     SETUPTOOLS_*
-extras =
-    testing
-allowlist_externals =
-    rm
-    mkdir
+set_env =
+    TOXINIDIR = {toxinidir}
 commands =
     rm -rf /tmp/ansible-sign-pytest
     mkdir /tmp/ansible-sign-pytest
     pytest --basetemp /tmp/ansible-sign-pytest --color=yes {posargs}
-
+allowlist_externals =
+    mkdir
+    rm
 
 [testenv:lint]
 description = Run code linters
-basepython = python3.9
-commands=
-    black --check .
-    flake8 --version
-    flake8 docs src tests
-    yamllint --version
-    yamllint -s .
-
+base_python = python3.9
+commands =
+    pre-commit run -a
 
 [testenv:{build,clean}]
 description =
     build: Build the package in isolation according to PEP517, see https://github.com/pypa/build
     clean: Remove old distribution files and temporary build artifacts (./build and ./dist)
-# https://setuptools.pypa.io/en/stable/build_meta.html#how-to-use-it
-skip_install = True
-changedir = {toxinidir}
+skip_install = true
 deps =
     build: build[virtualenv]
-passenv =
+pass_env =
     SETUPTOOLS_*
+change_dir = {toxinidir}
 commands =
     clean: python -c 'import shutil; [shutil.rmtree(p, True) for p in ("build", "dist", "docs/_build")]'
     clean: python -c 'import pathlib, shutil; [shutil.rmtree(p, True) for p in pathlib.Path("src").glob("*.egg-info")]'
     build: python -m build {posargs}
-
 
 [testenv:{docs,doctests,linkcheck}]
 description =
     docs: Invoke sphinx-build to build the docs
     doctests: Invoke sphinx-build to run doctests
     linkcheck: Check for broken links in the documentation
-passenv =
+deps =
+    -r {toxinidir}/docs/requirements.txt
+pass_env =
     SETUPTOOLS_*
-setenv =
-    DOCSDIR = {toxinidir}/docs
+set_env =
     BUILDDIR = {toxinidir}/docs/_build
+    DOCSDIR = {toxinidir}/docs
     docs: BUILD = html
     doctests: BUILD = doctest
     linkcheck: BUILD = linkcheck
-deps =
-    -r {toxinidir}/docs/requirements.txt
-    # ^  requirements.txt shared with Read The Docs
 commands =
     sphinx-build --color -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
-
 
 [testenv:publish]
 description =
     Publish the package you have been developing to a package index server.
     By default, it uses testpypi. If you really want to publish your package
     to be publicly accessible in PyPI, use the `-- --repository pypi` option.
-skip_install = True
-changedir = {toxinidir}
-passenv =
-    # See: https://twine.readthedocs.io/en/latest/
-    TWINE_USERNAME
+skip_install = true
+deps =
+    twine
+pass_env =
     TWINE_PASSWORD
     TWINE_REPOSITORY
-deps = twine
+    TWINE_USERNAME
+change_dir = {toxinidir}
 commands =
     python -m twine check dist/*
     python -m twine upload {posargs:--repository {env:TWINE_REPOSITORY:testpypi}} dist/*


### PR DESCRIPTION
- use pre-commit to orchestrate linters
- replace black and flake8 with ruff