### PR TITLE
Add finalize workflow for secure sonarcloud checks

### DIFF
--- a/.github/workflows/finalize.yml
+++ b/.github/workflows/finalize.yml
@@ -15,7 +15,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       (github.event.workflow_run.event == 'pull_request' ||
        (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'))
-    uses: ansible/team-devtools/.github/workflows/finalize.yml@fix/sonarcloud-workflow
+    uses: ansible/team-devtools/.github/workflows/finalize.yml@main
     with:
       run-id: ${{ github.event.workflow_run.id }}
       workflow-event: ${{ github.event.workflow_run.event }}


### PR DESCRIPTION
Related: [AAP-52660](https://issues.redhat.com/browse/AAP-52660)

Adds the `finalize` workflow for sonarcloud checks. Runs only after tox checks pass.
 
This creates support for sonarcloud scanning on PRs from forks.

Workflow will not run until merged.