### PR TITLE
Test release 0.1.1 on Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,36 +1,71 @@
 ---
-name: tox
-
-on:
-  merge_group:
+name: ansible-sign tests
+on:  # yamllint disable-line rule:truthy
   push:
-    branches:
-      - "main"
-      - "releases/**"
-      - "stable/**"
   pull_request:
-    branches:
-      - "main"
-  schedule:
-    - cron: "0 0 * * *"
-  workflow_call:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
-
-env:
-  FORCE_COLOR: 1 # tox, pytest, ansible-lint
-  PY_COLORS: 1
 
 jobs:
-  tox:
-    uses: ansible/team-devtools/.github/workflows/tox.yml@main
-    secrets: inherit
-    with:
-      jobs_producing_coverage: 5
-      min_python: "3.11"
-      other_names: |
-        docs
-        lint
-        pkg
+  python-tests:
+    name: Python ${{ matrix.python }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python: "3.8"
+            os: ubuntu-latest
+          - python: "3.9"
+            os: ubuntu-latest
+          - python: "3.10"
+            os: ubuntu-latest
+          - python: "3.10"
+            os: macos-latest
+          - python: "3.11"
+            os: ubuntu-latest
+          - python: "3.11"
+            os: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install system packages
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update && \
+          sudo apt-get -y install \
+            tmux \
+            ;
+
+      - name: Install system packages
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install \
+            tmux \
+            ;
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Run tests
+        run: tox -e py3
+
+      - name: Ensure docs build
+        run: tox -e docs
+  linters:
+    name: Linters
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install tox
+        run: pip install tox
+
+      - name: Run linters
+        run: tox -e lint


### PR DESCRIPTION
Temporary PR to ensure tests are passing with Python 3.11 on release 0.1.1.

This is a requirement from PDE to ensure AAP 2.4 packages work with Python 3.11.

This PR will be closed once tests are confirmed to pass.

Jira: [AAP-53469](https://issues.redhat.com/browse/AAP-53469)