### PR TITLE
fix: Downgrade python-gnupg requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ classifiers = [
 ]
 dependencies = [
   "distlib>=0.4.0",
-  "python-gnupg>=0.5.5"
+  "python-gnupg>=0.5.2" # Maximum version due to pulp constraints
 ]
 description = "Ansible content validation library and CLI"
 dynamic = ["version"]

--- a/uv.lock
+++ b/uv.lock
@@ -62,7 +62,7 @@ pkg = [
 [package.metadata]
 requires-dist = [
     { name = "distlib", specifier = ">=0.4.0" },
-    { name = "python-gnupg", specifier = ">=0.5.5" },
+    { name = "python-gnupg", specifier = ">=0.5.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Aligns the python-gnupg requirement with pulp.

Jira: [AAP-57366](https://issues.redhat.com/browse/AAP-57366)