### PR TITLE
fix: handle symlink loops gracefully in manifest processing

### DIFF
--- a/src/ansible_sign/checksum/differ/distlib_manifest.py
+++ b/src/ansible_sign/checksum/differ/distlib_manifest.py
@@ -41,7 +41,14 @@ class DistlibManifestChecksumFileExistenceDiffer(ChecksumFileExistenceDiffer):
             if not line or line[0] == "#":
                 continue
 
-            manifest.process_directive(line)
+            try:
+                manifest.process_directive(line)
+            except OSError as e:
+                # Handle symlink loops (errno 40: too many levels of symbolic links)
+                if e.errno == errno.ELOOP:
+                    # Skip this directive if it encounters a symlink loop
+                    continue
+                raise
 
         for path in manifest.files:
             files_set.add(os.path.relpath(path, start=self.root))


### PR DESCRIPTION
## Summary

Fixes #55

When using ansible-sign with roles that have been linted by the latest ansible-lint, a crash occurs due to circular symlinks created in the `.ansible` directory. The error:
```
OSError: [Errno 40] Too many levels of symbolic links
```

## Changes

- Added try/except block around `manifest.process_directive(line)`
- Catches OSError with errno.ELOOP (symlink loop error)
- Skips the problematic directive and continues processing
- Allows signing to complete successfully even with symlink loops present

## Test plan

- Test with a role that has `.ansible` symlink created by ansible-lint
- Verify that `ansible-sign project gpg-sign .` completes without error
- Existing tests should continue to pass
- The fix is defensive - it only catches the specific errno.ELOOP error